### PR TITLE
Duplicate Categories

### DIFF
--- a/Southport.Messaging.Email.SendGrid.Test/SendGridMessage_Test.cs
+++ b/Southport.Messaging.Email.SendGrid.Test/SendGridMessage_Test.cs
@@ -398,6 +398,32 @@ namespace Southport.Messaging.Email.SendGrid.Test
 
         #endregion
 
+        #region Categories Duplicated
+        
+        [Fact]
+        public async Task Send_Message_Duplicate_Categories()
+        {
+            const string emailAddress = "test1@southport.solutions";
+            var message = _factory.Create();
+            var responses = await message
+                .SetFromAddress("test2@test.southport.solutions")
+                .AddToAddress(emailAddress)
+                .SetSubject($"{SubjectPrefix}Simple")
+                .AddCategory("test_category")
+                .AddCategory("test_category")
+                .SetText("This is a test email.").Send();
+            
+
+            foreach (var response in responses)
+            {
+                _output.WriteLine(response.Message);
+                Assert.True(response.IsSuccessful);
+                Assert.Equal(emailAddress, response.EmailRecipient.EmailAddress.Address);
+            }
+        }
+
+        #endregion
+
         public void Dispose()
         {
             _httpClient.Dispose();

--- a/Southport.Messaging.Email.SendGrid/Message/Interfaces/ISendGridMessage.cs
+++ b/Southport.Messaging.Email.SendGrid/Message/Interfaces/ISendGridMessage.cs
@@ -16,8 +16,8 @@ namespace Southport.Messaging.Email.SendGrid.Interfaces
         string BatchId { get; set; }
 
         ISendGridMessage SetReplyTo(IEmailAddress emailAddress);
-        ISendGridMessage SetCategory(string tag);
-        ISendGridMessage SetCategories(List<string> categories);
+        ISendGridMessage AddCategory(string category);
+        ISendGridMessage AddCategories(List<string> categories);
         ISendGridMessage AddHeader(string key, string header);
         ISendGridMessage SetBatchId(string batchId);
 

--- a/Southport.Messaging.Email.SendGrid/Message/SendGridMessage.cs
+++ b/Southport.Messaging.Email.SendGrid/Message/SendGridMessage.cs
@@ -254,13 +254,13 @@ namespace Southport.Messaging.Email.SendGrid.Message
 
         public List<string> Categories { get; set; } = new();
 
-        public ISendGridMessage SetCategory(string tag)
+        public ISendGridMessage AddCategory(string category)
         {
-            Categories.Add(tag);
+            Categories.Add(category);
             return this;
         }
 
-        public ISendGridMessage SetCategories(List<string> categories)
+        public ISendGridMessage AddCategories(List<string> categories)
         {
             if (categories == null || !categories.Any())
             {

--- a/Southport.Messaging.Email.SendGrid/Message/SendGridMessage.cs
+++ b/Southport.Messaging.Email.SendGrid/Message/SendGridMessage.cs
@@ -708,7 +708,7 @@ namespace Southport.Messaging.Email.SendGrid.Message
 
             #region Categories
 
-            message.Categories = Categories.Any() ? Categories : null;
+            message.Categories = Categories.Any() ? Categories.Distinct().ToList() : null;
 
             #endregion
 


### PR DESCRIPTION
When sending an email to SendGrid, the Categories cannot be duplicated. This will ensure that only distinct Categories are added to the email. 